### PR TITLE
商品一覧機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
 
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
 
   def index
-    @items = Item.all
+    @items = Item.all.order(id: "DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :authenticate_user!, except: [:index]
 
   def index
     @items = Item.all.order(id: "DESC")

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -26,4 +26,6 @@ class Item < ApplicationRecord
   def image_presence
     errors.add(:image, 'must be attached') unless image.attached?
   end
+
+  has_one :item_order, dependent: :destroy
 end

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -1,0 +1,4 @@
+class ItemOrder < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+end

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -1,4 +1,9 @@
 class ItemOrder < ApplicationRecord
+  with_options presence: true do
+    validates :user_id
+    validates :item_id
+  end
+
   belongs_to :user
   belongs_to :item
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,4 +24,5 @@ class User < ApplicationRecord
   end
 
   has_many :items, dependent: :destroy
+  has_many :item_orders, dependent: :destroy
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,11 +133,11 @@
         <div class='item-img-content'>
           <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" %>
 
-          <%# 商品が売れていればsold outの表示 %>
+          <% if item.item_order != nil  %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outの表示 %>
+          <% end %>
 
         </div>
         <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,11 +126,12 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
+    <% @items.each do |item|%>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" %>
 
           <%# 商品が売れていればsold outの表示 %>
           <div class='sold-out'>
@@ -141,10 +142,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -154,28 +155,7 @@
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合のダミー %>
+      <% end %>
     </ul>
   </div>
   <%# //商品一覧 %>

--- a/db/migrate/20200729091529_create_items.rb
+++ b/db/migrate/20200729091529_create_items.rb
@@ -5,7 +5,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.text       :text,                   null: false
       t.integer    :category_id,            null: false, default: 1
       t.integer    :condition_id,           null: false, default: 1
-      t.integer    :including_postage_id,   null: false, default: false
+      t.integer    :including_postage_id,   null: false, default: 1
       t.integer    :consignor_location_id,  null: false, default: 1
       t.integer    :ready_time_id,          null: false, default: 1
       t.integer    :price,                  null: false, default: 1

--- a/db/migrate/20200731031719_create_item_orders.rb
+++ b/db/migrate/20200731031719_create_item_orders.rb
@@ -1,0 +1,10 @@
+class CreateItemOrders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :item_orders do |t|
+      t.references :user,                   foreign_key: true
+      t.references :item,                   foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_29_091529) do
+ActiveRecord::Schema.define(version: 2020_07_31_031719) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -31,6 +31,15 @@ ActiveRecord::Schema.define(version: 2020_07_29_091529) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "item_orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "item_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_item_orders_on_item_id"
+    t.index ["user_id"], name: "index_item_orders_on_user_id"
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -67,5 +76,7 @@ ActiveRecord::Schema.define(version: 2020_07_29_091529) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "item_orders", "items"
+  add_foreign_key "item_orders", "users"
   add_foreign_key "items", "users"
 end

--- a/spec/factories/item_orders.rb
+++ b/spec/factories/item_orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :item_order do
+    
+  end
+end

--- a/spec/models/item_order_spec.rb
+++ b/spec/models/item_order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ItemOrder, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
商品一覧機能の実装

# Why
商品を表示するため

# 動作時の画像キャプチャ
### 商品の一覧表示とSold Outの表示
- 一覧表示（木彫りのクマが売り切れている）
https://gyazo.com/e7ba6b3e95e1774c1c86e609ced3bb49
- Sequel Proのitemsテーブル（木彫りのクマの id は 1）
https://gyazo.com/adb8c5d852b002bcbd37ec82722735ce
- Sequel Proのitem_ordersテーブル（購入記録 = item_order に item_id: 1 が登録されている）
https://gyazo.com/d29168bbb3e9bed6d13a1132b3951ea4