### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,11 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.all.order(id: "DESC")
+  end
+
+  def show
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,6 +6,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find_by(id: params[:id])
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,12 +1,12 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_item, only: [:show]
 
   def index
     @items = Item.all.order(id: "DESC")
   end
 
   def show
-    @item = Item.find_by(id: params[:id])
   end
 
   def new
@@ -23,6 +23,10 @@ class ItemsController < ApplicationController
   end
   
   private
+  def set_item
+    @item = Item.find_by(id: params[:id])
+  end
+
   def item_params
     params.require(:item).permit(:name, :text, :category_id, :condition_id, :including_postage_id, :consignor_location_id, :ready_time_id, :price, :image).merge(user_id: current_user.id)
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
       <li class='list'>
         <%= link_to item_path(item) do %>
         <div class='item-img-content'>
-          <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <% if item.item_order != nil  %>
           <div class='sold-out'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
     <% @items.each do |item|%>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,65 +4,69 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sould outの表示をしましょう。 %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sould outの表示をしましょう。 %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <% if @item.item_order != nil  %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ￥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        (税込) 送料込み
+        (税込) 
+        <% if @item.including_postage_id == 2 %>
+        送料別
+        <% else @item.including_postage_id == 3 %>
+        送料込み
+        <% end %>
       </span>
     </div>
+    <%# ログインしていて、ユーザーが出品者の場合に表示 %>
+    <% if @item.user == current_user %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% end %>
 
-    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-    <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
+    <%# 商品が未購入、かつ、ユーザーが未ログイン、または、ログイン状態でも出品者とは異なる場合に表示 %>
+    <% if @item.item_order == nil && (!user_signed_in? || @item.user != current_user) %>
+     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.text %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= Category.find(@item.category_id)[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= Condition.find(@item.condition_id)[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= IncludingPostage.find(@item.including_postage_id)[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= ConsignorLocation.find(@item.consignor_location_id)[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= ReadyTime.find(@item.ready_time_id)[:name] %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root "items#index"
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :show, :new, :create]
 end


### PR DESCRIPTION
# What
商品詳細表示機能を実装

# Why
商品の詳細を表示するため

# 動作時の画面キャプチャ
### 商品詳細の表示
https://gyazo.com/ee8370cae300839704a69b47ade77053
### 商品購入前の表示
・未ログインユーザー→購入ボタンあり
https://gyazo.com/3c6e76b7c9ee8092d2cdcc27bfde2036
・出品者以外のユーザー（ログイン後）→購入ボタンあり
https://gyazo.com/114ce77732ddf982e77e0b799b811d66
・出品者（ログイン後）→購入ボタンなし、編集、削除ボタンあり
https://gyazo.com/9e180a3a7657bbf3298251a8a018c7de
### 商品購入後の表示
・未ログインユーザー→購入ボタンなし
https://gyazo.com/74970bd1f26be4b7075ba2bf18790d4c
・出品者以外のユーザー（ログイン後）→購入ボタンなし
https://gyazo.com/64281c7b794f4558194ff2b772e4a63a
・出品者（ログイン後）→購入ボタンなし、編集、削除ボタンあり
https://gyazo.com/d9d37c4b0a714901a84795a3477e21ab