### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,8 +35,11 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item.destroy
-    redirect_to items_path
+    if @item.destroy
+      redirect_to items_path
+    else
+      render item_path(@item)
+    end
   end
   
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :owner?, only: [:edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :owner?, only: [:edit, :update, :delete]
 
   def index
     @items = Item.all.order(id: "DESC")
@@ -16,14 +16,6 @@ class ItemsController < ApplicationController
 
   def edit
   end
-
-  def update
-    if @item.update(item_params)
-      redirect_to item_path(@item)
-    else
-      render :edit
-    end
-  end
   
   def create
     @item = Item.new(item_params)
@@ -32,6 +24,19 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def update
+    if @item.update(item_params)
+      redirect_to item_path(@item)
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to items_path
   end
   
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
     <% if @item.user == current_user %>
       <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
-      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <%= link_to '削除', item_path(@item), method: :delete, class:'item-destroy' %>
     <% end %>
 
     <%# 商品が未購入、かつ、ユーザーが未ログイン、または、ログイン状態でも出品者とは異なる場合に表示 %>

--- a/spec/models/order_form_spec.rb
+++ b/spec/models/order_form_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe OrderForm, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
商品削除機能を実装
# Why
商品削除を削除できるようにするため
# 動作画面のキャプチャ
### 削除の手順
- 削除前の商品一覧
https://gyazo.com/a09100f5c27e05116154ced4be3dddf6
- 商品詳細から削除ボタンを押下
https://gyazo.com/fcfc06cfb7b50a4001d13857b8b3223c
- 削除後、商品一覧から該当商品が消える
https://gyazo.com/9b3c6e51c96e5925f7f87c2f3ce34fa4